### PR TITLE
Add wiki content

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -89,3 +89,39 @@ You need to fix it with this command :
 ```
 
 Reboot and your keyboard is in now AZERTY mode.
+
+## How to mount docker data on a different SSD?
+
+If you want to store DAppNode data on a different device, to have more space or any other reason, follow these steps, as root user or using sudo.
+
+- Stop Docker service
+
+  `systemctl stop docker`
+
+- Create a new mountpoint for docker data. As an example:
+
+  `mkdir /data`
+
+- Add your partition on the new device to `/etc/fstab`. You can identify its UUID using the `blkid` tool. Make sure your device is properly partitioned first. Your new line in `/etc/fstab` should look like this:
+
+  `UUID=b311b983-bda6-4e9f-835c-266d40d64f07 /data/ ext4 defaults 0 0`
+
+- Mount your SSD drive
+
+  `mount /data`
+
+- Move docker data to the mountpoint
+
+  `mv /var/lib/docker/* /data/`
+
+- Edit Docker settings to use the alternative location. Edit `/etc/docker/daemon.json` as follows:
+
+```
+{
+  "data-root": "/data"
+}
+```
+
+- Restart docker
+
+  `systemctl start docker`

--- a/docs/install.md
+++ b/docs/install.md
@@ -148,18 +148,63 @@ Please, after installation be aware that the ethereum blockchain will take some 
 
 If you are experiencing any problem or just want to make sure you are running the latest DAppNode versions, execute this command in the DAppNode terminal. This will update the core packages to the latest versions without erasing any data from your volumes.
 
-⚠️ Please note that volumes are not deleted, but any EXTRA_OPTS set by the user in the packages config **must be set again** after using this script to restore the system ⚠️  
+⚠️ Please note that volumes are not deleted, but any EXTRA_OPTS set by the user in the packages config **must be set again** after using this script to restore the system ⚠️
 
 ```
 sudo wget -O - https://installer.dappnode.io | sudo UPDATE=true bash
 ```
+
 ### How to uninstall DAppNode
 
 This command will uninstall DAppNode components (but not docker et al.):
 ⚠️ BEWARE! It will also delete all volumes and stored data!⚠️
+
 ```
 wget -qO - https://uninstaller.dappnode.io  |  sudo bash
 ```
+
+## DAppNodeARM Installation Guide
+
+## Minimum requirements
+
+- Raspberry model: 4, 3B+
+- Raspberry RAM: 8GB, 4GB
+- Micro SD free space: 8 or more
+- Connectivity to the Rpi
+
+## Installation of the ISO image
+
+1. First download the file `DAppNodeARM.img.gz/zip` from [here](https://github.com/dappnode/DAppNode/releases/tag/v0.2.39)
+2. Unzip the file.
+3. Write the image into the microSD. To do that, there are different tools such as Raspberry [pi imager](https://www.raspberrypi.org/downloads/) and Rufus.
+4. Insert the microSD into the Rpi.
+5. Switch on the Rpi and wait for the startup process.
+6. Login with:
+
+- **user**: _dappnode_
+- **password**: _dappnodepi_
+
+7. DAppnode installation.
+
+## DAppNode Installation
+
+1. Before proceeding with the DAppNode installation you must have internet connection, the best option is to have a wired internet connection. If not possible follow this [tutorial](https://raspberrypihq.com/how-to-connect-your-raspberry-pi-to-wifi/#:~:text=To%20tell%20the%20Raspberry%20Pi,conf.&text=Remember%20to%20replace%20this%20with,Ctrl%2BX%20followed%20by%20Y.) to setup your connection from the command line.
+2. Once the ISO has been successfully installed, its time to install DAppNode. In the terminal run the command: `sudo dappnodepi-install`
+3. **Congratulations!** You are done, your DAppNode is installed in your Rpi.
+
+## Helpful tips:
+
+In order to interact with the Rpi in some way there are 2 main options:
+
+1. Using the Rpi via ssh: first, you will have to set some requirements, following this [tutorial](https://magpi.raspberrypi.org/articles/ssh-remote-control-raspberry-pi). As well as setting the Rpi IP static, as is shown in the following [tutorial](https://www.ionos.com/digitalguide/server/configuration/provide-raspberry-pi-with-a-static-ip-address/).
+2. Using the RPpi via HDMI: you will have to have an extra mouse and keyboard, as well an HDMI and a monitor.
+
+Few tips regarding using external SSD on your RPI4:
+
+1. Check out our guide on mounting and using external disk with docker [here](https://github.com/dappnode/DAppNode/wiki/Mount-docker-data-on-a-different-SSD).
+2. You may run into issues with some disk enclosures so be sure to check out [this](https://www.raspberrypi.org/forums/viewtopic.php?t=245931).
+
+### **Questions?** Reach out to us in the [Discourse Forum](https://discourse.dappnode.io/).
 
 ## Enter your DAppNode!
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,33 +12,33 @@ Once you fill the fields and press the register button, DAppNode provides you wi
 
 You should save your token in a secure place like a password manager, paper, etc. In this case, we would save this:
 
-~~~
+```
 4LMB9w3l50Yljwr6bIgQ
-~~~
+```
 
 ### How to access to my DAppNode using the recovery token
 
 Firstly, we have to go to the login page of our DAppNode:
 
-![login](./images/login.png "")
+![login](./images/login.png)
 
 We should select the option "Forgot password?". It will appear a field where you can reset your password using the recovery token. In this example, we would use the token <code>4LMB9w3l50Yljwr6bIgQ</code>. You have to use your recovery token.
 
-![reset password with the recovery token](./images/reset_password_with_recovery_token.png "")
+![reset password with the recovery token](./images/reset_password_with_recovery_token.png)
 
 After confirming the recovery token, you can define an admin user in DAppNode and his password in the same way you did the first time you connect.
 
-![Defining the new password](./images/sign_in_image.png "")
+![Defining the new password](./images/sign_in_image.png)
 
 Remember using a password with the next properties:
 
-* Minimum 8 characters
-* At least one Cap letter
-* At least one number
+- Minimum 8 characters
+- At least one Cap letter
+- At least one number
 
 Once you filled the field and press the register button, dappnode will provide a recovery token.
 
-![Obtaining your recovery token](./images/recovery_token.png "")
+![Obtaining your recovery token](./images/recovery_token.png)
 
 We write down and save that token and we accept we have copied our recovery token. We log in with our new credentials and we have access to our DAppNode.
 
@@ -48,17 +48,17 @@ In case we have lost both the password and the recovery token, we need to access
 
 Once we are in our DAppNodeMachine, we type the next command which shows us the recovery token:
 
-~~~
+```
 cat /usr/src/dappnode/DNCORE/admin-recovery-token.txt ; echo
-~~~
+```
+
 The command does the next:
 
-* The admin-recover-token.txt is where the token is saved.
-* The <code>; echo</code> is used to make easier the read of the token.
+- The admin-recover-token.txt is where the token is saved.
+- The <code>; echo</code> is used to make easier the read of the token.
 
-After inserting the command we obtain the recovery token we have to use to reset our password. 
+After inserting the command we obtain the recovery token we have to use to reset our password.
 On the above section, How to access to my DAppNode using the recovery token you can reset your password with this recovery token.
-
 
 ## VPN Connection issues
 
@@ -148,12 +148,11 @@ If you are not on a 4 GB (ideally 8 GB) RAM configuration/ or your HD has not a 
 
 Using Parity, it is also possible that the initial sync gets stuck at a given snapshot of the first sync, if this happens try removing ETHCHAIN volume and let the sync start again. To do so you have to enter in Packages/System packages / Ethchain / Controls and hit remove volume, the existing synced snapshots will be erased and the sync will start again.
 
-When using Parity, it might happen that when the snapshots finish syncin you are still very far away the current block height so it will take ages to finish the sync block by block. You can try to set up the Parity flag ```--warp-barrier (current block height -30.000 blocks)``` so the sync takes a higher number of snapshots what will decrease the number of spare blocks left to be synced individually.  Have a look at this example. 
+When using Parity, it might happen that when the snapshots finish syncin you are still very far away the current block height so it will take ages to finish the sync block by block. You can try to set up the Parity flag `--warp-barrier (current block height -30.000 blocks)` so the sync takes a higher number of snapshots what will decrease the number of spare blocks left to be synced individually. Have a look at this example.
 
 <p align="center">
     <img width="1000"src="https://github.com/dappnode/DAppNodeDocs/blob/master/docs/images/warpbarrier.jpg?raw=true">
 </p>
-
 
 ### I can't access the ADMIN UI
 
@@ -192,19 +191,35 @@ Execute this command in your DAppNode terminal, this will update the core packag
 
 ### I can't install a package using its ENS or IPFS hash
 
-If the package has been uploaded to IPFS but it still does not have enough propagation in the network,it might be hard to install that package unless you are connected to an IPFS node that that allows direct or routed access to that package. As you can automatically peer-connect two IPFS nodes hosted in a DAppNode you can ask a DAppNode peer that already has installed hat package to connect your nodes. To do so, in the IPFS packages screen Go to Connect with peers and send the link to your peer. 
+If the package has been uploaded to IPFS but it still does not have enough propagation in the network,it might be hard to install that package unless you are connected to an IPFS node that that allows direct or routed access to that package. As you can automatically peer-connect two IPFS nodes hosted in a DAppNode you can ask a DAppNode peer that already has installed hat package to connect your nodes. To do so, in the IPFS packages screen Go to Connect with peers and send the link to your peer.
 
+## My DAppNode does not detect an external SSD
+
+DAppNode can automatically detect and mount external SSD drives connected via USB, thanks to a fork of a utility called [usbmount](https://github.com/dappnode/usbmount). If you plugged your drive and you cannot see it in the list of available mountpoints, check the following points.
+
+---
+
+### Partition format
+
+The most likely issue is you used a drive which is not formatted with a format natively compatible with DAppNode OS. We don't support partitions in NTFS (Windows) or APFS, HFS+, etc. (MacOS).
+The recommended filesystem format is ext4, but you can also use FAT32.
+
+### Disk not formatted
+
+Make sure your disk is formatted with a valid partition table and partitions. Use a utility like [gparted](https://gparted.org/) for Linux, or [AOMEI Partition Assistant](https://www.diskpart.com/) for Windows to accomplish that.
+
+### Internal disks
+
+If you added a disk internally in your DAppNode (it's not USB connected), it's not going to be mounted automatically, and you will need to configure it manually adding an entry in `/etc/fstab`. As a reference you can follow [this guide](https://medium.com/@sh.tsang/partitioning-formatting-and-mounting-a-hard-drive-in-linux-ubuntu-18-04-324b7634d1e0)
 
 <p align="center">
     <img width="1000"src="https://github.com/dappnode/DAppNodeDocs/blob/master/docs/images/connectwithpeers.png?raw=true">
 </p>
 
-### I need to uninstall my DAppNode 
+### I need to uninstall my DAppNode
 
 If for whichever strange reason you have to uninstall your DAppNode server you can do so by typing the following command in the DAppNode server console
 
-```wget -qO - https://uninstaller.dappnode.io  |  sudo bash```
+`wget -qO - https://uninstaller.dappnode.io | sudo bash`
 
 This command will uninstall DAppNode components (but not docker et al.): ⚠️ BEWARE! It will also delete all volumes and stored data!⚠️
-
-


### PR DESCRIPTION
This PR is for moving all the interesting content which is in the wiki to the docs. 
This is the content we have in wiki.

- [ ] Home  -> Not added, nothing new
- [ ] Challenges -> Outdated information
- [ ]  Connect DAppNode via Wireless interface -> I don't know if this works right now. I can't test it.
- [ ] DAppNode Installation Guide -> It's in the docs.
- [ ] DAppNode Migration Guide to v0.2.x (OpenVPN) -> it's in the docs
- [ ]  DAppNode Package Development -> I did not add it, but it would be nice to improve it and include it in the docs
- [ ] DAppNode packages manifest -> It is in docs.
- [x]  DAppNodeARM Installation Guide -> I add it in the install section on the docs.
- [ ]  Installation of development versions of Core -> I am not sure if this work now. I did not add it. 
- [ ] Manifest JSON schema -> It's in the docs.
- [x] Mount docker data on a different SSD -> I add it to Faqs section
- [ ]  OpenVPN Client Guide -> It's on the docs. 
- [ ] Recommended specs for DAppNode hardware -> It's outdated information about dappnode hardware spec
- [ ]  Suggested options for Debian based ISO installation 
- [ ]  Suggested options for Ubuntu server installation
- [ ]  Support FAQ -> Solution for a problem, but It seem to be an old problem (2018).
- [ ] Technical issues -> It's outdated.
- [x]  Troubleshoot mountpoints -> Add it to the Troubleshooting section in the docs.
- [ ]  VPN Backups -> It can be added but I think there is a better way to do it right now, with backup dappnode functionality.
- [ ]  Zenhub Methodology -> I am not sure this has to be in the docs.

If you think there is something that I did not add it but it's should be in the docs. Comment it and I will add it. 