### PR TITLE
Fix image paths

### DIFF
--- a/docs/get-started/installation/arm-hardware/installation.md
+++ b/docs/get-started/installation/arm-hardware/installation.md
@@ -13,7 +13,7 @@ sidebar_position: 2
 3. Write the image into the microSD. To do that, there are different tools such as [Raspberry pi imager](https://www.raspberrypi.org/software/) and Rufus(for windows). In this example we used Raspberry pi imager.
 
 <p align="center">
-    <img src="../../../../static/img/arm_installation_1.png"/>
+    <img src="../../../../img/arm_installation_1.png"/>
 </p>
 
 4. Insert the microSD into the Rpi.
@@ -25,7 +25,7 @@ sidebar_position: 2
 You will see this screen.
 
 <p align="center">
-    <img src="../../../../static/img/arm_installation_2.png"/>
+    <img src="../../../../img/arm_installation_2.png"/>
 </p>
 
 The default credentials are.

--- a/docs/get-started/installation/custom-hardware/installation/iso.md
+++ b/docs/get-started/installation/custom-hardware/installation/iso.md
@@ -25,41 +25,41 @@ Also, DAppNode is intended to run 24/7 so if you install it in a laptop or deskt
 Insert the USB into your Server and prepare to install a Debian distribution. You will have to make sure that your Server boots from the USB. If you succeed at booting up from your USB, you will be greeted with this screen or a similar one:
 
 <p align="center">
-    <img src="../../../../static/img/VirtualBox_install.png"/>
+    <img src="../../../../img/VirtualBox_install.png"/>
 </p>
 
 Select a language.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_1.png"/>
+    <img src="../../../../img/iso_install_1.png"/>
 </p>
 
 Select a location.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_2.png"/>
+    <img src="../../../../img/iso_install_2.png"/>
 </p>
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_3.png"/>
+    <img src="../../../../img/iso_install_3.png"/>
 </p>
 
 Select a keyboard configuration.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_4.png"/>
+    <img src="../../../../img/iso_install_4.png"/>
 </p>
 
 Type a hostname, this is like the name your machine will have on the network. It's not important.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_5.png"/>
+    <img src="../../../../img/iso_install_5.png"/>
 </p>
 
 Define a password for the user root.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_6.png"/>
+    <img src="../../../../img/iso_install_6.png"/>
 </p>
 
 > :warning: Write down this password, you will need it in case you need to access as root to the cli of DAppNode.
@@ -67,85 +67,85 @@ Define a password for the user root.
 Select an username for your DAppNode and define a password.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_7.png"/>
+    <img src="../../../../img/iso_install_7.png"/>
 </p>
 
 > :warning: Write down the user for dappnode and the password you define for him.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_8.png"/>
+    <img src="../../../../img/iso_install_8.png"/>
 </p>
 
 Set up your time zone.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_9.png"/>
+    <img src="../../../../img/iso_install_9.png"/>
 </p>
 
 Partition disk configuration. On this guide we will use the second option **Partitioning method: [Guided - use entire disk and set up LVM]**.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_10.png"/>
+    <img src="../../../../img/iso_install_10.png"/>
 </p>
 
 After choosing the disk, we need to define the partioning scheme. We will select **All files in one partition (recommended for new users)**.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_11.png"/>
+    <img src="../../../../img/iso_install_11.png"/>
 </p>
 
 Confirm we will write the disk.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_12.png"/>
+    <img src="../../../../img/iso_install_12.png"/>
 </p>
 
 We want to use all the disk ont he partioning process. So we dont modificate the value.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_13.png"/>
+    <img src="../../../../img/iso_install_13.png"/>
 </p>
 
 Confirm we want to write the changes to disks.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_14.png"/>
+    <img src="../../../../img/iso_install_14.png"/>
 </p>
 
 The next decision depends of you. We resommend to select yes because you dont have to confirm all the operations.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_15.png"/>
+    <img src="../../../../img/iso_install_15.png"/>
 </p>
 
 Install the grub.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_16.png"/>
+    <img src="../../../../img/iso_install_16.png"/>
 </p>
 
 Select the disk.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_17.png"/>
+    <img src="../../../../img/iso_install_17.png"/>
 </p>
 
-If you have a static IP you should define here. In other case, leave the field blank.
+If you have a IP you should define here. In other case, leave the field blank.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_18.png"/>
+    <img src="../../../../img/iso_install_18.png"/>
 </p>
 
 You will see this message indicating you have finished this installation.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_19.png"/>
+    <img src="../../../../img/iso_install_19.png"/>
 </p>
 
 The machine will restart and you will see this screen.
 
 <p align="center">
-    <img src="../../../../static/img/iso_install_20.png"/>
+    <img src="../../../../img/iso_install_20.png"/>
 </p>
 
 Log in into the machine with the user you have defined before and the password.

--- a/docs/user-guide/support/troubleshooting.md
+++ b/docs/user-guide/support/troubleshooting.md
@@ -4,11 +4,15 @@
 
 The first time you access your DAppnode using the VPN, appear the next image:
 
-![Signin](../../../static/img/sign_in_image.png)
+<p align="center">
+    <img src="../../../img/sign_in_image.png"/>
+</p>
 
 Once you fill the fields and press the register button, DAppNode provides you with a recovery code. If you forget te DAppNode's Password you will be able to access using this token.
 
-![Recovery Token](../../../static/img/recovery_token.png)
+<p align="center">
+    <img src="../../../img/recovery_token.png"/>
+</p>
 
 You should save your token in a secure place like a password manager, paper, etc. In this case, we would save this:
 
@@ -20,15 +24,21 @@ You should save your token in a secure place like a password manager, paper, etc
 
 Firstly, we have to go to the login page of our DAppNode:
 
-![login](../../../static/img/login.png)
+<p align="center">
+    <img src="../../../img/login.png"/>
+</p>
 
 We should select the option "Forgot password?". It will appear a field where you can reset your password using the recovery token. In this example, we would use the token <code>4LMB9w3l50Yljwr6bIgQ</code>. You have to use your recovery token.
 
-![reset password with the recovery token](../../../static/img/reset_password_with_recovery_token.png)
+<p align="center">
+    <img src="../../../img/reset_password_with_recovery_token.png"/>
+</p>
 
 After confirming the recovery token, you can define an admin user in DAppNode and his password in the same way you did the first time you connect.
 
-![Defining the new password](../../../static/img/sign_in_image.png)
+<p align="center">
+    <img src="../../../img/sign_in_image.png"/>
+</p>
 
 Remember using a password with the next properties:
 
@@ -38,7 +48,9 @@ Remember using a password with the next properties:
 
 Once you filled the field and press the register button, dappnode will provide a recovery token.
 
-![Obtaining your recovery token](../../../static/img/recovery_token.png)
+<p align="center">
+    <img src="../../../img/recovery_token.png"/>
+</p>
 
 We write down and save that token and we accept we have copied our recovery token. We log in with our new credentials and we have access to our DAppNode.
 

--- a/docs/user-guide/ui/access/vpn.md
+++ b/docs/user-guide/ui/access/vpn.md
@@ -22,14 +22,14 @@ DAppNode supports 2 kinds of VPN: OpenVPN and Wireguard. Below you have a little
 Firstly, you should go to VPN page, clicking on the VPN tab on the left menu. You sill see a view where you can select 2 tabs: OpenVPN and wireguard.
 
 <p align="center">
-    <img src="../../../../static/img/vpn_view.png"/>
+    <img src="../../../../img/vpn_view.png"/>
 </p>
 
 In case you want to set up openVPN, follow the instruction of OpenVPN.
 On the other hand, if you wish to use wireguard, click on the tab Wireguard, you will need to install the wireguard package how you see in the below image.
 
 <p align="center">
-    <img src="../../../../static/img/wireguard_view_installed.png"/>
+    <img src="../../../../img/wireguard_view_installed.png"/>
 </p>
 
 In case you want to set up wireguard, follow the instruction of Wireguard.
@@ -345,19 +345,19 @@ Content to be added soon.
 In your mobile, go to the playstore, then look for `wireguard` and select this app and install it:
 
 <p align="center">
-    <img src="../../../../static/img/wireguard_android_install.jpg"/>
+    <img src="../../../../img/wireguard_android_install.jpg"/>
 </p>
 
 Then, if you open the app you will see the next image:
 
 <p align="center">
-    <img src="../../../../static/img/wireguard_android_set_up.jpg"/>
+    <img src="../../../../img/wireguard_android_set_up.jpg"/>
 </p>
 
 Click on the blue circle button on the right bottom:
 
 <p align="center">
-    <img src="../../../../static/img/wireguard_android_set_up_2.jpg"/>
+    <img src="../../../../img/wireguard_android_set_up_2.jpg"/>
 </p>
 
 You can obtain the configuration scanning the QR you obtain on the vpn/wireguard view, download the file and import it or copy the contain of the configuration.
@@ -367,7 +367,7 @@ You can obtain the configuration scanning the QR you obtain on the vpn/wireguard
 Automatically, after installing DAppNode you should see the next image and a link where can download the credentials.
 
 <p align="center">
-    <img src="../../../../static/img/VirtualBox_console.png"/>
+    <img src="../../../../img/VirtualBox_console.png"/>
 </p>
 
 If it does not happen, you can generate the OpenVPN credentials manually with the command:

--- a/docs/user-guide/ui/access/wifi.md
+++ b/docs/user-guide/ui/access/wifi.md
@@ -17,7 +17,7 @@ Once you have access to the UI, you should modify these predefined values on the
 > :warning: Please immediately change the name of the WIFI and the password by setting up the new values in the WIFI section you can access by clicking on the Wi-Fi tab on the left menu.
 
 <p align="center">
-    <img src="../../../../static/img/wi-fi-tab.png"/>
+    <img src="../../../../img/wi-fi-tab.png"/>
 </p>
 
 Once you have access to the wi-fi section, there are 2 tabs:

--- a/docs/user-guide/ui/community.md
+++ b/docs/user-guide/ui/community.md
@@ -3,7 +3,7 @@
 In this section you can find all the channels you can find us and how to can contribute to this project.
 
 <p align="center">
-    <img src="../../../../static/img/community_view.png"/>
+    <img src="../../../../img/community_view.png"/>
 </p>
 
 ## Discord Channel

--- a/docs/user-guide/ui/dappstore.md
+++ b/docs/user-guide/ui/dappstore.md
@@ -7,7 +7,7 @@ DAppStore is the place where you can look for, install and update the package yo
 You can access the DAppStore view clicking on the DAppStore option which appears on the left menu on the UI. You should see something similar to this image:
 
 <p align="center">
-    <img src="../../../../static/img/dappstore_view.png"/>
+    <img src="../../../../img/dappstore_view.png"/>
 </p>
 
 The main tasks you can do here are:
@@ -28,7 +28,7 @@ There are 2 ways of using this view for searching a package:
 The main view of the DAppStore shows the packages you can install.
 
 <p align="center">
-    <img src="../../../../static/img/installing_a_package_1.png"/>
+    <img src="../../../../img/installing_a_package_1.png"/>
 </p>
 
 Every of this card represents a package, the information you can obtain from that is the next:
@@ -43,7 +43,7 @@ Every of this card represents a package, the information you can obtain from tha
 You can use this bar to look for the package by its name or its IPFS Hash.
 
 <p align="center">
-    <img src="../../../../static/img/dappstore_nav_bar.png"/>
+    <img src="../../../../img/dappstore_nav_bar.png"/>
 </p>
 
 ## Install a package
@@ -51,7 +51,7 @@ You can use this bar to look for the package by its name or its IPFS Hash.
 Once you have located the package you want to install. Click on the **GET** button. You will be redirected to the next view:
 
 <p align="center">
-    <img src="../../../../static/img/installing_a_package_2.png"/>
+    <img src="../../../../img/installing_a_package_2.png"/>
 </p>
 
 On this view you can observe the next information about the package:

--- a/docs/user-guide/ui/dashboard.md
+++ b/docs/user-guide/ui/dashboard.md
@@ -3,7 +3,7 @@
 The dashboard view is the main page of the DAppNode interface.s
 
 <p align="center">
-    <img src="../../../../static/img/dashboard_numered.png"/>
+    <img src="../../../../img/dashboard_numered.png"/>
 </p>
 
 1. **Dashboard**: To back to the main view of the DAppNode interface.

--- a/docs/user-guide/ui/initial-configurations/first-steps.md
+++ b/docs/user-guide/ui/initial-configurations/first-steps.md
@@ -25,7 +25,7 @@ After **Log In** for the first time into your DAppNode you will see this screen.
 1. This pop up will inform you about some required configurations. Click on the Start button.
 
 <p align="center">
-    <img src="../../../../static/img/first_steps_1.png"/>
+    <img src="../../../../img/first_steps_1.png"/>
 </p>
 
 2. The first thing you need to set up is the type of client you want to use. We recommend this set-up:
@@ -36,20 +36,20 @@ After **Log In** for the first time into your DAppNode you will see this screen.
 This configuration can be modified whatever you want. You can find all the information with all the details about this decision in [this section](./first-steps).
 
 <p align="center">
-    <img src="../../../../static/img/first_steps_2.png"/>
+    <img src="../../../../img/first_steps_2.png"/>
 </p>
 
 3. The next window are asking you about the System Auto Updates. If you turn on this option, your DAppNode will be updated automatically when it detects there is a new version enabled. 24 hours after DAppNode releases there is a new version, it will start the installation of the new version.
    From DAppNode we recommend to turn on this option.
 
 <p align="center">
-    <img src="../../../../static/img/first_steps_3.png"/>
+    <img src="../../../../img/first_steps_3.png"/>
 </p>
 
 4. CONGRATULATIONS!!! This screen shows that all this configuration are finished.
 
 <p align="center">
-    <img src="../../../../static/img/first_steps_4.png"/>
+    <img src="../../../../img/first_steps_4.png"/>
 </p>
 
 ## What is the next?

--- a/docs/user-guide/ui/initial-configurations/select-a-client.md
+++ b/docs/user-guide/ui/initial-configurations/select-a-client.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 The first time you enter to the admin UI of DAppNode, you will have to take this decision. Firstly, it's a decision you can modify whatever you want. From DAppNode we think it's so important to explain best as possible what this selection means. Then, you will see the next window.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_repository.png"/>
+    <img src="../../../../img/system_view_repository.png"/>
 </p>
 
 You can select 3 different options. To understand correctly what are the consecuences, we will explain in a short way the context situation and the pros and cons of every option.

--- a/docs/user-guide/ui/packages.md
+++ b/docs/user-guide/ui/packages.md
@@ -12,7 +12,7 @@ On this view, we can check what packages we have installed in our DAppNodes. You
 My packages refers to the packages the user have installed and they are not essential for the performance of DAppNode.
 
 <p align="center">
-    <img src="../../../../static/img/packages_view_1.png"/>
+    <img src="../../../../img/packages_view_1.png"/>
 </p>
 
 ## System packages
@@ -20,5 +20,5 @@ My packages refers to the packages the user have installed and they are not esse
 They are the packages that are essential for DAppNode or including a feature that is so important for DAppNode.
 
 <p align="center">
-    <img src="../../../../static/img/packages_view_2.png"/>
+    <img src="../../../../img/packages_view_2.png"/>
 </p>

--- a/docs/user-guide/ui/recommended-set-ups/add-ipfs-peers.md
+++ b/docs/user-guide/ui/recommended-set-ups/add-ipfs-peers.md
@@ -28,7 +28,7 @@ Firstly, DAppNode has a server with all the packages. In this way, we are sure a
 You should go to the System > Peers or you can try to [use this link](http://my.dappnode/#/system/add-ipfs-peer) if you are connected vpn or via wifi.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_peers.png"/>
+    <img src="../../../../img/system_view_peers.png"/>
 </p>
 
 ### Get your IPFS peer link

--- a/docs/user-guide/ui/recommended-set-ups/add-vpn-devices.md
+++ b/docs/user-guide/ui/recommended-set-ups/add-vpn-devices.md
@@ -25,7 +25,7 @@ To set up VPN correctly, you need to open the ports 8092 TCP and 1194 UDP. You h
 You can use openvpn or wireguard. You are free to set up whatever you prefer or even both. Firstly, go to the VPN page, you can do it by clicking on the VPN on the right menu of the UI. Select the tab of the vpn you want to set up.
 
 <p align="center">
-    <img src="../../../static/img/wireguard_view_1.png"/>
+    <img src="../../../img/wireguard_view_1.png"/>
 </p>
 
 In case wireguard is not installed and you want to use it, intall the package by clicking on the link.
@@ -36,7 +36,7 @@ If you have wireguard package installed you should see this page after clicking 
 Once you have installed the Wireguard package, you will be able to see this page:
 
 <p align="center">
-    <img src="../../../static/img/wireguard_view_2.png"/>
+    <img src="../../../img/wireguard_view_2.png"/>
 </p>
 
 You can use the profile is created by default. Or create a new one and delete this. To create a new one follow the next steps.
@@ -44,19 +44,19 @@ You can use the profile is created by default. Or create a new one and delete th
 1. Type a name for your device on the field **Add Device** and click on the button o press intro.
 
 <p align="center">
-    <img src="../../../static/img/add_wireguard_device_1.png"/>
+    <img src="../../../img/add_wireguard_device_1.png"/>
 </p>
 
 If the device was created correctly, this one will appears below.
 
 <p align="center">
-    <img src="../../../static/img/add_wireguard_device_2.png"/>
+    <img src="../../../img/add_wireguard_device_2.png"/>
 </p>
 
 2. Click on the button **Get link** of this device you have created. You will be redirected to the next page:
 
 <p align="center">
-    <img src="../../../static/img/add_wireguard_device_3.png"/>
+    <img src="../../../img/add_wireguard_device_3.png"/>
 </p>
 
 If you will use a wireguard client in a laptop or pc you need to copy that text, it's the configuration of wireguard for the device that you have added. You can copy it by clicking on the **Copy remote config**.
@@ -116,19 +116,19 @@ Content to be added soon.
 In your mobile, go to the playstore, then look for `wireguard` and select this app and install it:
 
 <p align="center">
-    <img src="../../../../static/img/wireguard_android_install.jpg"/>
+    <img src="../../../../img/wireguard_android_install.jpg"/>
 </p>
 
 Then, if you open the app you will see the next image:
 
 <p align="center">
-    <img src="../../../../static/img/wireguard_android_set_up.jpg"/>
+    <img src="../../../../img/wireguard_android_set_up.jpg"/>
 </p>
 
 Click on the blue circle button on the right bottom:
 
 <p align="center">
-    <img src="../../../../static/img/wireguard_android_set_up_2.jpg"/>
+    <img src="../../../../img/wireguard_android_set_up_2.jpg"/>
 </p>
 
 You can obtain the configuration scanning the QR you obtain on the vpn/wireguard view, download the file and import it or copy the contain of the configuration.
@@ -136,7 +136,7 @@ You can obtain the configuration scanning the QR you obtain on the vpn/wireguard
 ## OpenVPN
 
 <p align="center">
-    <img src="../../../static/img/openvpn_view_1.png"/>
+    <img src="../../../img/openvpn_view_1.png"/>
 </p>
 
 You can use the profile is created by default. Or create a new one and delete this. To create a new one follow the next steps.
@@ -144,19 +144,19 @@ You can use the profile is created by default. Or create a new one and delete th
 1. Type a name for your device on the field **Add Device** and click on the button o press intro.
 
 <p align="center">
-    <img src="../../../static/img/add_wireguard_device_1.png"/>
+    <img src="../../../img/add_wireguard_device_1.png"/>
 </p>
 
 If the device was created correctly, this one will appears below.
 
 <p align="center">
-    <img src="../../../static/img/add_openvpn_device_1.png"/>
+    <img src="../../../img/add_openvpn_device_1.png"/>
 </p>
 
 2. Click on the button **Get link** of this device you have created. You will be redirected to the next page:
 
 <p align="center">
-    <img src="../../../static/img/add_openvpn_device_2.png"/>
+    <img src="../../../img/add_openvpn_device_2.png"/>
 </p>
 
 These are the recommended Open VPN clients for each OS:

--- a/docs/user-guide/ui/recommended-set-ups/auto-updates.md
+++ b/docs/user-guide/ui/recommended-set-ups/auto-updates.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 We recommend having activated the auto-updates, at least for the System Packages. If you activate this option, when your DAppNode detect there is a new version, the update will be done after 24 hours later. This is valid for non-major updates, in which an admin intervention will always be needed.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_auto-updates.png"/>
+    <img src="../../../../img/system_view_auto-updates.png"/>
 </p>
 
 The packages that are not system packages, like Prysm, geth, bitcoin, bee, etc. If there is an update of the official application, the package with this version will release for DAppNode several days later because we have to test this new version before releasing the package to the DAppStore.
@@ -15,7 +15,7 @@ The packages that are not system packages, like Prysm, geth, bitcoin, bee, etc. 
 You should go to System Auto updates and click on the button that is on the **Enabled** button on the right side.
 
 <p align="center">
-    <img src="../../../../static/img/auto-updates-on.png"/>
+    <img src="../../../../img/auto-updates-on.png"/>
 </p>
 
 ## Turn off the auto-updates
@@ -23,5 +23,5 @@ You should go to System Auto updates and click on the button that is on the **En
 In case you don't want to activate the auto-updates, you have to see something like:
 
 <p align="center">
-    <img src="../../../../static/img/auto-updates-off.png"/>
+    <img src="../../../../img/auto-updates-off.png"/>
 </p>

--- a/docs/user-guide/ui/recommended-set-ups/backup-functionality.md
+++ b/docs/user-guide/ui/recommended-set-ups/backup-functionality.md
@@ -20,25 +20,25 @@ We will show how to do it step by step:
 1. Firstly, you need to go to Packages view. Selecting the Packages item on the left menu.
 
 <p align="center">
-    <img src="../../../../static/img/backup-functionality_1.png"/>
+    <img src="../../../../img/backup-functionality_1.png"/>
 </p>
 
 2. Select one package that have sensitive information. For example, bee package. Click on the name of the package you want to do the backup, and select the **Backup** tab.
 
 <p align="center">
-    <img src="../../../../static/img/backup-functionality_2.png"/>
+    <img src="../../../../img/backup-functionality_2.png"/>
 </p>
 
 3. Click on the **Backup now** button.
 
 <p align="center">
-    <img src="../../../../static/img/backup-functionality_3.png"/>
+    <img src="../../../../img/backup-functionality_3.png"/>
 </p>
 
 4. You will see a pop up where you can choose where to store the compressed file with your backup file.
 
 <p align="center">
-    <img src="../../../../static/img/backup-functionality_4.png"/>
+    <img src="../../../../img/backup-functionality_4.png"/>
 </p>
 
 And **that's all**, you have a backup that package, in this example I would have a backup of my bee package.
@@ -54,13 +54,13 @@ Following the same example above, let's imagine that my be package crashed and a
 1. Go to the view of the package, in this case, Packages > Bee > Backup and click on the **Restore** button:
 
 <p align="center">
-    <img src="../../../../static/img/backup-functionality_5.png"/>
+    <img src="../../../../img/backup-functionality_5.png"/>
 </p>
 
 2. It will appear a pop up asking you select your backup file, you have to select the same compressed file you download when you do the backup, as simple as that.
 
 <p align="center">
-    <img src="../../../../static/img/backup-functionality_6.png"/>
+    <img src="../../../../img/backup-functionality_6.png"/>
 </p>
 
 After this two steps, you would have restore your package.

--- a/docs/user-guide/ui/sdk.md
+++ b/docs/user-guide/ui/sdk.md
@@ -3,7 +3,7 @@
 This page is mainly for developers. If you a developer and you would like to create a package by yourself. You have a link to the tool we use to create a package **DAppNodeSDK**.
 
 <p align="center">
-    <img src="../../../../static/img/sdk_view.png"/>
+    <img src="../../../../img/sdk_view.png"/>
 </p>
 
 In case you are interested in learning how to create a package, you can find the necessary content in the developer section of the documentation.

--- a/docs/user-guide/ui/support.md
+++ b/docs/user-guide/ui/support.md
@@ -5,7 +5,7 @@
 In this screen you will have an overview of the functioning of your DAppNode with checks that will indicate you if there is any problem for the normal operation of your DAppNode. You can contribute to DAppNode´s improvement by opening issues directly from the ADMIN UI.
 
 <p align="center">
-    <img src="../../../../static/img/support_view_auto-diagnose.png"/>
+    <img src="../../../../img/support_view_auto-diagnose.png"/>
 </p>
 
 ## Report
@@ -13,7 +13,7 @@ In this screen you will have an overview of the functioning of your DAppNode wit
 When you click the "Report" tab you will chave the option of sending the issue with a prepopulated form that will be automatically loaded in the report screen. You can also choose to open the issue without any data. There are 2 types of scan.
 
 <p align="center">
-    <img src="../../../../static/img/support_view_report.png"/>
+    <img src="../../../../img/support_view_report.png"/>
 </p>
 
 ## Ports
@@ -21,7 +21,7 @@ When you click the "Report" tab you will chave the option of sending the issue w
 This functionality let the user know the status of the port of its DAppNode, sometimes know certainly this status can be hard. Because of that, this feature was implemented.
 
 <p align="center">
-    <img src="../../../../static/img/support_view_port_scan.png"/>
+    <img src="../../../../img/support_view_port_scan.png"/>
 </p>
 
 In this view you will be able to know:
@@ -48,5 +48,5 @@ Note: The UDP protocol ports cannot be scanned without prior settings on the rou
 This tab allows easy access to the DAppNode logs in order to debug errors. We work hard to make this tab irrelevant to you, but for the time being, if you are experiencing any issue, these logs will help our support team help you identify and fix any problem. You will also find a button to download a log report file.
 
 <p align="center">
-    <img src="../../../../static/img/support_activity.png"/>
+    <img src="../../../../img/support_activity.png"/>
 </p>

--- a/docs/user-guide/ui/system.md
+++ b/docs/user-guide/ui/system.md
@@ -9,7 +9,7 @@ In this section you can see the general metrics of your machine:
 - **Statistics of your machine**: RAM usage, Disk Space and CPU usage.
 - **Volumes**: The volumes of your DAppNode and how much space they occupy.
 <p align="center">
-    <img src="../../../../static/img/system_view_main.png"/>
+    <img src="../../../../img/system_view_main.png"/>
 </p>
 
 ## Notifications
@@ -17,7 +17,7 @@ In this section you can see the general metrics of your machine:
 In case you want to set up telegram notifications, this view let you use a telegram bot to show the DAppNode message in telegram.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_notifications.png"/>
+    <img src="../../../../img/system_view_notifications.png"/>
 </p>
 
 If you are interested in enable this kind of notifications, we recommend you follow this guide [how to set up telegram notifications on DAppNode](https://forum.dappnode.io/t/set-up-your-dappnode-telegram-bot/816/4).
@@ -29,7 +29,7 @@ You can now choose if you want your packages to be automatically updated by enab
 This feature is valid for non major updates, in which an admin intervention will always be needed.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_auto-updates.png"/>
+    <img src="../../../../img/system_view_auto-updates.png"/>
 </p>
 
 ## Repository
@@ -38,7 +38,7 @@ You can find a more detailed information on the section [select a type of client
 This view is the same that you saw in that step.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_repository.png"/>
+    <img src="../../../../img/system_view_repository.png"/>
 </p>
 
 Here you can choose several options:
@@ -54,12 +54,12 @@ As we said before if you want to know the pros and cons of this decisions, we re
 
 In the network section we can do some technical stuff:
 
-**Static IP**: usually, the IP we have in our houses are dynamics, so we have not a static IP, because of this situation, DAppNode uses DynDNS, DynDNS associates an IP to a static direction like 0773a23d34aed273.dyndns.dappnode.io, for example. It's necessary to use a static direction to run some services, DynDNS is the solution to this problem. If your IP is static for any reason, and you don't want to use DynDNS, you can set up with this field.
+- IP\*\*: usually, the IP we have in our houses are dynamics, so we have not a IP, because of this situation, DAppNode uses DynDNS, DynDNS associates an IP to a direction like 0773a23d34aed273.dyndns.dappnode.io, for example. It's necessary to use a direction to run some services, DynDNS is the solution to this problem. If your IP is for any reason, and you don't want to use DynDNS, you can set up with this field.
 
 **HTTPs Portal**: to see this option you need to install de HTTPS package. Here you can expose services using the protocol HTTPS. What does it mean? If you expose for example geth, you expose your geth RPC to the Internet, so you can use metamask from anywhere. You have to be careful with his feature. In this section we have listed the services we "recommend" or we think is interesting to expose to.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_network.png"/>
+    <img src="../../../../img/system_view_network.png"/>
 </p>
 
 ## Profile
@@ -67,7 +67,7 @@ In the network section we can do some technical stuff:
 Here you can modify the password that is required to access to the UI.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_profile.png"/>
+    <img src="../../../../img/system_view_profile.png"/>
 </p>
 
 ## Peers
@@ -75,7 +75,7 @@ Here you can modify the password that is required to access to the UI.
 This section is about IPFS peers. You can find more detail information about this on [add ipfs peers](recommended-set-ups/add-ipfs-peers.md), there you can know more about what is IPFS, why is important to add peers, etc.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_peers.png"/>
+    <img src="../../../../img/system_view_peers.png"/>
 </p>
 
 On this view, we can do two thing:
@@ -88,7 +88,7 @@ On this view, we can do two thing:
 It shows some security checks of your DAppNode.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_security.png"/>
+    <img src="../../../../img/system_view_security.png"/>
 </p>
 
 ## Advanced
@@ -100,13 +100,13 @@ The advanced area collect many different functionalities
 You can change the name that appears on the UI on the top right. It's only a visual change, so it's not a sentitive modification.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_advanced_1.png"/>
+    <img src="../../../../img/system_view_advanced_1.png"/>
 </p>
 
 For example, if we type that name and click on the button **Change dappnode Name**, the name will be what we wrote on the field.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_advanced_2.png"/>
+    <img src="../../../../img/system_view_advanced_2.png"/>
 </p>
 
 ### SSH
@@ -119,7 +119,7 @@ The following space let the user manage the ssh configuration of his DAppNode. Y
 - **Change SSH port**:
 
 <p align="center">
-    <img src="../../../../static/img/system_view_advanced_3.png"/>
+    <img src="../../../../img/system_view_advanced_3.png"/>
 </p>
 
 #### Check SSH status
@@ -143,7 +143,7 @@ If you want to change the port DAppNode use for ssh , you can change it by typin
 This configuration is so sensitive. Here you can update the docker version of your DAppNode. We refer to docker-compose and the docker engine.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_advanced_4.png"/>
+    <img src="../../../../img/system_view_advanced_4.png"/>
 </p>
 
 In case you want update docker versions, you must update the docker compre first, and after the docker engine.
@@ -164,7 +164,7 @@ You have to click on the **Check requirements** button. Several checks will be d
 Remove the local cache of Aragon Package Manager (APM) entries, manifests, avatars. Also remove the user action logs shown in the Activity tab.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_advanced_5.png"/>
+    <img src="../../../../img/system_view_advanced_5.png"/>
 </p>
 
 ### Clear main db
@@ -172,7 +172,7 @@ Remove the local cache of Aragon Package Manager (APM) entries, manifests, avata
 Remove the local database which contains critical information about your DAppNode, such as the dyndns identity, Ips registry, telegram configuration etc.
 
 <p align="center">
-    <img src="../../../../static/img/system_view_advanced_6.png"/>
+    <img src="../../../../img/system_view_advanced_6.png"/>
 </p>
 
 ## Power
@@ -180,5 +180,5 @@ Remove the local database which contains critical information about your DAppNod
 If you need to reboot or shut down your server as a last resource, you can do it from this section. Please be aware that if you shut down your server you will only be able to switch it on again when you have psysical access to your DAppNode.
 
 <p align="center">
-    <img src="../../../../static/img/powermanagement.png"/>
+    <img src="../../../../img/powermanagement.png"/>
 </p>

--- a/docs/user-guide/ui/vpn.md
+++ b/docs/user-guide/ui/vpn.md
@@ -12,7 +12,7 @@ There are 2 tabs:
 OpenVPN is installed by default. You will see the next image.
 
 <p align="center">
-    <img src="../../../static/img/openvpn_view_1.png"/>
+    <img src="../../../img/openvpn_view_1.png"/>
 </p>
 
 The options are:
@@ -30,7 +30,7 @@ You have a full guide about how to set up OpenVPN and the OpenVPN client [here](
 In this case, wireguard is not installed in your DAppNode. You can do it by clicking on the link that appears.
 
 <p align="center">
-    <img src="../../../static/img/wireguard_view_1.png"/>
+    <img src="../../../img/wireguard_view_1.png"/>
 </p>
 
 ### Wireguard is installed
@@ -38,7 +38,7 @@ In this case, wireguard is not installed in your DAppNode. You can do it by clic
 If the Wireguard package is installed you will see something like the following screen.
 
 <p align="center">
-    <img src="../../../static/img/wireguard_view_1.png"/>
+    <img src="../../../img/wireguard_view_1.png"/>
 </p>
 
 You have a full guide about how to set up Wireguard and the Wireguard client [here](./recommended-set-ups/add-vpn-devices).

--- a/docs/user-guide/ui/wi-fi.md
+++ b/docs/user-guide/ui/wi-fi.md
@@ -9,7 +9,7 @@ On the status page, you can turn on/off the wifi package. You can do this in cas
 > :warning: If you are accessing via wifi, check you can connect to your DAppNode using another method in case you will turn off the wifi.
 
 <p align="center">
-    <img src="../../../../static/img/wifi_view_1.png"/>
+    <img src="../../../../img/wifi_view_1.png"/>
 </p>
 
 ## Credentials
@@ -21,5 +21,5 @@ In this tab, you can change the current password of the wifi.
 > :warning: Remember you need to use a strong password for the wifi.
 
 <p align="center">
-    <img src="../../../../static/img/wifi_view_2.png"/>
+    <img src="../../../../img/wifi_view_2.png"/>
 </p>


### PR DESCRIPTION
Change the paths of the images, on docusaurus there 2 main ways to show an image:
* Using HTML code, we are using this way because the style can be modified easily.
*  Markdown
One difference in deployment is that if you use markdown.
The path you can use is the relative path of the repo, for example: `../../../static/img/image_example_1.png`
In case you use the HTML code, you need to use the relative path after executing the build. So the path is slightly different, it would be:
`../../img/image_example_1.png

This PR modify all the path to be correct after building command.