### PR TITLE
Fix fileUpload description in fileUpload section

### DIFF
--- a/docs/developers/wizard.md
+++ b/docs/developers/wizard.md
@@ -213,7 +213,7 @@ target:
 
 #### fileUpload
 
-To allow hosting a specific package volume into a different drive or mountpoint
+To allow uploading user files to the package container
 
 ```yaml
 target:


### PR DESCRIPTION
https://docs.dappnode.io/developers/wizard#fileupload

Screenshot with the wrong description below:

<img width="481" alt="image" src="https://user-images.githubusercontent.com/7695193/144641321-ecf3456a-d40a-4a81-9e5c-62daeac33bd6.png">
