### PR TITLE
Custom hardware install boot mode warning.

### DIFF
--- a/docs/get-started/installation/custom-hardware/installation/iso.md
+++ b/docs/get-started/installation/custom-hardware/installation/iso.md
@@ -22,6 +22,8 @@ Also, DAppNode is intended to run 24/7 so if you install it on a laptop or deskt
 
 ## Boot from ISO
 
+> :warning: If you encounter a corrupted display during installation, ensure BIOS boot mode is: UEFI.
+
 Insert the USB into your Server and prepare to install a Debian distribution. You will have to make sure that your Server boots from the USB. If you succeed at booting up from your USB, you will be greeted with this screen or a similar one:
 
 <p align="center">


### PR DESCRIPTION
Installation on custom hardware without the correct boot mode creates artefacts; the note should reduce user support demands.

<img width="895" alt="image" src="https://user-images.githubusercontent.com/631881/152243931-85f39d98-d135-4617-a280-61af387bee02.png">
