### PR TITLE
update outdated info

### DIFF
--- a/docs/get-started/installation/custom-hardware/installation/overview.md
+++ b/docs/get-started/installation/custom-hardware/installation/overview.md
@@ -9,13 +9,11 @@ DAppNode project is open source which means you can install it on your hardware.
 - [Installing with a script](./script.md)
 - [Installing with an ISO](./iso.md)
 
-There are some little differences that we have to mention. These differences are details and it does not affect the user experience.
+There are some little differences that we have to mention. These differences are important for more technical users. It does not affect the performance of the DAppNode but it does have a slightly different user experience that is generally limited to advanced users who interact with command line often.
 
-If you install DAppNode with an ISO, you will have 2 core packages installed by default:
+If you install DAppNode with an ISO:
 
-- Wireguard
-- Https
+The root account will be locked from SSH when installed via ISO, and the host account (default username: `dappnode`) will need to manually be added to the sudoers file to access root directories or use the `sudo` command.
 
-Wireguard is a VPN client and HTTPS is a feature that lets you securely expose your endpoint to the public.
+Both the install script and ISO install the same core packages.
 
-If you install DAppNode using the script, these packages are not currently included and you can install them on your own. For the next release these packages will be installed automatically.

--- a/docs/user-guide/ui/access/local-proxy.md
+++ b/docs/user-guide/ui/access/local-proxy.md
@@ -13,5 +13,3 @@ When you use the local network proxy you are limited to the admin UI dashboard a
 ## Enable/Disable from UI
 
 You can Enable/Disable this access method from the UI from the Wifi page, on the tab Local Network.
-
-> :information_source: If Local Proxy will not work initially if you did the installation by script. You will need to install the https package to be able to enable this access method. If you want to use the local proxy method as the first access method after the installation, we recommend the ISO installation.

--- a/docs/user-guide/ui/access/local-proxy.md
+++ b/docs/user-guide/ui/access/local-proxy.md
@@ -8,7 +8,7 @@ If you are connected on the same network of your DAppNode and you did the instal
 
 # Note
 
-When you use the local network proxy you are limited to the admin UI dashboard at `dappnode.local` and cannot access any other UI's such as Prysm, Avalanche, Mysterium, DMS, etc.  You must use VPN (preferably Wireguard) or the DAppNode's own WiFi hotspot to access those pages.
+When you use the local network proxy you are limited to the admin UI dashboard at `dappnode.local` and cannot access any other UI's such as Prysm, Avalanche, Mysterium, DMS, etc.  You must use a VPN (preferably Wireguard) or the DAppNode's own WiFi hotspot to access those pages.
 
 ## Enable/Disable from UI
 


### PR DESCRIPTION
updated the part that said the ISO installs HTTPS and Wireguard by default but the script doesn't but will in the future.  The future is now and those packages are installed by the script as well.  I added a note about installing via script for root and sudo access for advanced users.