### PR TITLE
Use full path instead relative

### DIFF
--- a/docs/user-guide/ui/initial-configurations/first-steps.md
+++ b/docs/user-guide/ui/initial-configurations/first-steps.md
@@ -33,7 +33,7 @@ After **Log In** for the first time into your DAppNode you will see this screen.
    - Turn on the Use remote during syncing or errors
    - The client, we don't have a preference between geth, nethermind ...
 
-This configuration can be modified whatever you want. You can find all the information with all the details about this decision in [this section](./first-steps).
+This configuration can be modified whatever you want. You can find all the information with all the details about this decision in [this section](https://docs.dappnode.io/user-guide/ui/initial-configurations/select-a-client).
 
 <p align="center">
     <img src="../../../../img/first_steps_2.png"/>


### PR DESCRIPTION
The first steps file is no ton the same path that the next, so is more reliable using the full path in this specific case