### PR TITLE
Update docusaurus version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@algolia/client-search": "^4.5.1",
-    "@docusaurus/core": "2.0.0-alpha.74",
-    "@docusaurus/preset-classic": "2.0.0-alpha.74",
+    "@docusaurus/core": "2.0.0-beta.20",
+    "@docusaurus/preset-classic": "2.0.0-beta.20",
     "@mdx-js/react": "^1.6.21",
     "@types/react": "17.0.37",
     "clsx": "^1.1.1",


### PR DESCRIPTION
Update to the latest stable version [2.0.0-beta.20](https://docusaurus.io/docs)