### PR TITLE
Add local search bar themes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -118,13 +118,20 @@ module.exports = {
             editUrl:
             'https://github.com/dappnode/DAppNodeDocs/blob/master',
         },
-        blog: {
-          showReadingTime: true,
-          // Please change this to your repo.
-        },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+      },
+    ],
+  ],
+  themes: [
+    // ... Your other themes.
+    [
+      require.resolve("@easyops-cn/docusaurus-search-local"),
+      {
+        hashed: true,
+        docsRouteBasePath: "/",
+        language: "en",
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@algolia/client-search": "^4.5.1",
     "@docusaurus/core": "2.0.0-beta.20",
     "@docusaurus/preset-classic": "2.0.0-beta.20",
+    "@easyops-cn/docusaurus-search-local": "^0.23.2",
     "@mdx-js/react": "^1.6.21",
     "@types/react": "17.0.37",
     "clsx": "^1.1.1",


### PR DESCRIPTION
We need to define the easyoops search local bar, docroutebasepath "/" because we have our files in that path and language is en.

Context:
Remove blog section, its not used in our documentation