### PR TITLE
Hardcoded ISO download to 0.2.66

### DIFF
--- a/docs/user/quick-start/Core/installation.md
+++ b/docs/user/quick-start/Core/installation.md
@@ -71,7 +71,7 @@ When you want to perform a clean installation by installing the base operating s
 
 #### Get the ISO
 
-You can get the image downloading directly from [DAppNodeISO](https://iso.dappnode.io/) or if you prefer you can build it from the [source](https://github.com/dappnode/DAppNode#install-dappnode-with-iso).
+You can get the image downloading directly from [DAppNodeISO](https://github.com/dappnode/DAppNode/releases/download/v0.2.66/DAppNode-v0.2.66-debian-bullseye-amd64.iso) or if you prefer you can build it from the [source](https://github.com/dappnode/DAppNode#install-dappnode-with-iso).
 
 #### Burn the ISO in a USB
 


### PR DESCRIPTION
The ISO being downloaded now by the users is version 0.2.56, but we are already in v0.2.66, so I hardcoded it to the new version in the meantime we are not able to update https://iso.dappnode.io/