### PR TITLE
Add CNAME

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+https://docs.dappnode.io


### PR DESCRIPTION
Add CNAME to avoid having to manually set custom domain in gh pages settings.

See https://github.com/tschaub/gh-pages/issues/236