### PR TITLE
Update solo.md

### DIFF
--- a/docs/user/staking/gnosis-chain/solo.md
+++ b/docs/user/staking/gnosis-chain/solo.md
@@ -120,7 +120,7 @@ Because the native token of Gnosis Chain is xDAI (you pay fees in it), but the s
 ### 1. Exit the validator from the Dappnode UI
 
 :::warning
-Make sure that your validator have a `0x01` type withdrawal address before exiting your validator or you will lose your funds. In the [consensus explorer](https://gnosischa.in/), if your withdrawal address shows as an address that starts with a `0x00` it means that your withdrawal address needs to be upgraded to a `0x01`, please refer to the guide in the [Gnosis Chain documentation](https://docs.gnosischain.com/node/management/withdrawals#how-to-change-the-withdrawal-credential). If your validator already shows a `0x01` address, you DON'T need to follow these steps.
+It is recommended to update your withdrawal credentials to the `0x01` type before exiting your validator. Updating your withdrawal credentials later, when your node is stopped, is more difficult. To check if you already have updated withdrawal credentials you can check your validators in the [consensus explorer](https://gnosischa.in/), if your withdrawal address shows as an address that starts with a `0x00` it means that your withdrawal address needs to be upgraded to a `0x01`, please refer to the guide in the [Gnosis Chain documentation](https://docs.gnosischain.com/node/management/withdrawals#how-to-change-the-withdrawal-credential). If your validator already shows a `0x01` address, you DON'T need to follow these steps.
 :::
 
 ![Gnosis Withdrawals](/img/gnosiswithdrawals1.png)


### PR DESCRIPTION
Making this warning a bit more factual as thankfully exiting a validator with a 0x00 withdrawal credential doesn't result in a loss of funds but an offline node after the exit will make the withdrawal credential update harder.