### PR TITLE
Update base edit page URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/dappnode/DappnodeDocs",
+          editUrl: "https://github.com/dappnode/DappnodeDocs/edit/master",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
fix(config): update edit URL so that "Edit this page" links are prepended with "edit/master" so that they resolve to the appropriate edit page instead of returning 404. Fixes  #433.