### PR TITLE
Add installation documentation for Linux and macOS

### DIFF
--- a/docs/user/getting-started/choose-your-path.md
+++ b/docs/user/getting-started/choose-your-path.md
@@ -1,6 +1,6 @@
 ---
 title: "Choose your path"
-llm_description: "Entry point to choose between using pre-installed Dappnode or installing on your own machine."
+llm_description: "Entry point to choose between using pre-installed Dappnode or installing on your own machine (Linux or macOS)."
 ---
 
 # Choose your path
@@ -18,9 +18,9 @@ Interested in purchasing a Dappnode? Explore our <a href="https://dappnode.io">o
     <p>I have bought a Dappnode or I already installed it</p>
   </a>
 
-  <a href="/docs/user/install/iso" className="card">
+  <a href="/docs/user/install/overview" className="card">
     <img src="/img/install_dappnode.png" alt="Install Dappnode" />
     <h2>I want to install Dappnode</h2>
-    <p>I own a machine where I want to install Dappnode software</p>
+    <p>Install on Linux (Debian/Ubuntu) or macOS</p>
   </a>
 </div>

--- a/docs/user/install/linux.md
+++ b/docs/user/install/linux.md
@@ -1,0 +1,71 @@
+---
+title: "Linux (Debian/Ubuntu)"
+llm_description: "Overview of installing Dappnode on Linux: ISO and script methods for server and desktop use cases."
+---
+
+# Linux (Debian/Ubuntu)
+
+Dappnode runs natively on Debian-based Linux distributions. You can install it on a dedicated server for 24/7 operation or on your personal Linux desktop or laptop.
+
+## Installation Methods
+
+### 1. [ISO Installation](/docs/user/install/iso)
+
+The ISO method performs a clean install: it wipes the disk and installs Dappnode over Debian. This is the recommended approach for dedicated machines.
+
+- **Best for**: New dedicated servers, users who want a turnkey setup.
+- **Supported architectures**: amd64
+
+### 2. [Script Installation](/docs/user/install/script)
+
+The script method installs Dappnode on top of an existing Debian or Ubuntu system. It offers more flexibility through flags that control which components are installed.
+
+- **Best for**: Existing Debian/Ubuntu systems, cloud servers, ARM devices, or users who want more control over the installation.
+
+## Server vs Desktop Installation
+
+The installer supports different modes depending on whether your machine will be a dedicated server or a personal desktop:
+
+### Server (24/7, dedicated machine)
+
+Install the full Dappnode package set. This is the default behavior:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash
+```
+
+This installs all core components including HTTPS, BIND, IPFS, VPN, WIREGUARD, DAPPMANAGER, WIFI, NOTIFICATIONS, and PREMIUM.
+
+**Connectivity options after installation:**
+
+- **WiFi**: Scan for `DAppNodeWIFI` and connect. Get credentials with `dappnode_wifi`.
+- **Wireguard VPN** (recommended): Import credentials from `dappnode_wireguard`.
+- **OpenVPN**: Import credentials from `dappnode_openvpn`.
+- **Local Proxy**: Connect to the same router and go to `http://dappnode.local`.
+
+### Desktop / Personal Computer (lite mode)
+
+If you want to run Dappnode on your personal Linux desktop or laptop, use the `--lite` flag. This installs a reduced set of components (BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, PREMIUM) without WIFI, IPFS, or HTTPS:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --lite
+```
+
+**Connectivity options after installation:**
+
+- **Wireguard VPN** (recommended): Import credentials from `dappnode_wireguard`.
+- **OpenVPN**: Import credentials from `dappnode_openvpn`.
+
+:::caution .dappnode domains on Desktop mode
+When running in `--lite` (desktop) mode, `.dappnode` domain resolution is currently under investigation and may not work as expected. This is a known limitation that is expected to be fixed in a future release.
+:::
+
+Once connected via VPN, access the Dappnode UI at [http://my.dappnode](http://my.dappnode).
+
+## Next Steps
+
+- [ISO Installation guide](/docs/user/install/iso) — step-by-step clean install
+- [Script Installation guide](/docs/user/install/script) — install on an existing system
+- [Advanced Script Options](/docs/user/install/script/advanced) — all flags and environment variables
+- [ARM Installation](/docs/user/install/arm) — ARM-specific instructions
+- [Dappnode Commands](/docs/user/install/dappnode-commands) — CLI reference

--- a/docs/user/install/linux.md
+++ b/docs/user/install/linux.md
@@ -5,7 +5,7 @@ llm_description: "Overview of installing Dappnode on Linux: ISO and script metho
 
 # Linux (Debian/Ubuntu)
 
-Dappnode runs natively on Debian-based Linux distributions. You can install it on a dedicated server for 24/7 operation or on your personal Linux desktop or laptop.
+Dappnode runs natively on Debian-based Linux distributions (amd64 and arm64). You can install it on a dedicated server for 24/7 operation or on your personal Linux desktop or laptop.
 
 ## Installation Methods
 
@@ -21,6 +21,7 @@ The ISO method performs a clean install: it wipes the disk and installs Dappnode
 The script method installs Dappnode on top of an existing Debian or Ubuntu system. It offers more flexibility through flags that control which components are installed.
 
 - **Best for**: Existing Debian/Ubuntu systems, cloud servers, ARM devices, or users who want more control over the installation.
+- **Supported architectures**: amd64, arm64
 
 ## Server vs Desktop Installation
 

--- a/docs/user/install/macos.md
+++ b/docs/user/install/macos.md
@@ -1,0 +1,96 @@
+---
+title: "macOS Installation"
+llm_description: "Guide to install Dappnode on macOS via script, covering both desktop and server modes."
+---
+
+# macOS Installation
+
+Dappnode can be installed on macOS (Apple Silicon and Intel) using the installation script. The installer automatically detects your Mac model and adjusts the installation accordingly:
+
+- **Server-class Macs** (Mac mini, Mac Studio, Mac Pro): Full installation with all services, suitable for 24/7 operation.
+- **Desktop/Laptop Macs** (MacBook, iMac): Minimal installation optimized for personal use alongside your day-to-day work.
+
+## Prerequisites
+
+Before installing Dappnode, you need:
+
+- [Docker Desktop for Mac](https://docs.docker.com/desktop/install/mac-install/) installed and running
+- `curl` or `wget` (macOS includes `curl` by default)
+
+:::info Docker Desktop
+Make sure Docker Desktop is running before starting the installation. You can verify it by running `docker ps` in your terminal.
+:::
+
+## Installation
+
+### Desktop / Personal Mac (MacBook, iMac)
+
+If you are running Dappnode on a Mac that you also use as your personal computer, use the `--minimal` flag. This installs only the essential Dappnode components (BIND, DAPPMANAGER, NOTIFICATIONS, PREMIUM), keeping your system lightweight:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --minimal
+```
+
+### Server Mac (Mac mini, Mac Studio, Mac Pro)
+
+For always-on Macs intended to run as dedicated servers, use the full installation:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash
+```
+
+The installer automatically detects server-class Mac models and installs the full package set including WIFI, IPFS, VPN, WIREGUARD, and HTTPS.
+
+:::tip
+If you have a Mac mini that you use as a personal desktop rather than a server, you can force the minimal installation by passing `--minimal`.
+:::
+
+## Connecting to Dappnode
+
+After installation, the script will display your VPN credentials. How you connect depends on your installation type:
+
+### Desktop / Personal Mac
+
+Since Dappnode is running locally on the same machine, connect using:
+
+- **Wireguard VPN** (recommended): Import the Wireguard credentials displayed after installation into the [Wireguard app](https://apps.apple.com/app/wireguard/id1451685025). Use `dappnode_wireguard --localhost` to get credentials optimized for local connections.
+- **OpenVPN**: Import the OpenVPN credentials into your preferred OpenVPN client. Use `dappnode_openvpn` to retrieve them.
+
+Once connected via VPN, access the Dappnode UI at [http://my.dappnode](http://my.dappnode).
+
+### Server Mac
+
+For a server Mac on your local network, you have additional connectivity options:
+
+- **WiFi**: Scan for `DAppNodeWIFI` and connect. Get WiFi credentials with `dappnode_wifi`.
+- **Wireguard VPN** (recommended): Import credentials from `dappnode_wireguard` into the Wireguard app.
+- **OpenVPN**: Import credentials from `dappnode_openvpn` into your OpenVPN client.
+
+Once connected, access the Dappnode UI at [http://my.dappnode](http://my.dappnode).
+
+## macOS-Specific Notes
+
+- **Docker Desktop**: Dappnode runs inside Docker Desktop on macOS. Make sure Docker Desktop is configured to start at login if you want Dappnode to be available after a reboot.
+- **File paths**: On macOS, Dappnode files are stored under `~/dappnode/` instead of `/usr/src/dappnode/`.
+- **Host scripts**: Some Linux-specific host operations are automatically disabled on macOS (`DISABLE_HOST_SCRIPTS=true`).
+- **Sleep/Suspend**: If your Mac goes to sleep, Docker containers will be paused. Disable sleep in System Settings for server usage.
+
+## Restore to the Latest Version
+
+To update Dappnode to the latest version without erasing any data:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo UPDATE=true bash
+```
+
+## Uninstall
+
+To uninstall Dappnode components:
+
+```bash
+wget -qO - https://uninstaller.dappnode.io | sudo bash
+```
+
+:::info
+For advanced installation options (custom packages, IPFS endpoints, etc.), see the [Advanced Script Options](/docs/user/install/script/advanced) page.
+:::

--- a/docs/user/install/macos.md
+++ b/docs/user/install/macos.md
@@ -58,6 +58,10 @@ Since Dappnode is running locally on the same machine, connect using:
 
 Once connected via VPN, access the Dappnode UI at [http://my.dappnode](http://my.dappnode).
 
+:::tip
+In order to access `.dappnode` domains from same macOS machine you need to connect to VPN with `--localhost` flag to ensure the correct routing of requests.
+:::
+
 ### Server Mac
 
 For a server Mac on your local network, you have additional connectivity options:

--- a/docs/user/install/macos.md
+++ b/docs/user/install/macos.md
@@ -54,7 +54,7 @@ After installation, the script will display your VPN credentials. How you connec
 Since Dappnode is running locally on the same machine, connect using:
 
 - **Wireguard VPN** (recommended): Import the Wireguard credentials displayed after installation into the [Wireguard app](https://apps.apple.com/app/wireguard/id1451685025). Use `dappnode_wireguard --localhost` to get credentials optimized for local connections.
-- **OpenVPN**: Import the OpenVPN credentials into your preferred OpenVPN client. Use `dappnode_openvpn` to retrieve them.
+- **OpenVPN**: Import the OpenVPN credentials into your preferred OpenVPN client. Use `dappnode_openvpn --localhost` to retrieve them.
 
 Once connected via VPN, access the Dappnode UI at [http://my.dappnode](http://my.dappnode).
 

--- a/docs/user/install/macos.md
+++ b/docs/user/install/macos.md
@@ -28,7 +28,7 @@ Make sure Docker Desktop is running before starting the installation. You can ve
 If you are running Dappnode on a Mac that you also use as your personal computer, use the `--lite` flag. This installs a reduced package set (BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, PREMIUM), keeping your system lightweight while enabling VPN access:
 
 ```bash
-sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --lite
+curl -fsSL https://installer.dappnode.io | bash -s -- --lite
 ```
 
 ### Server Mac (Mac mini, Mac Studio, Mac Pro)
@@ -36,7 +36,7 @@ sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --lite
 For always-on Macs intended to run as dedicated servers, use the full installation:
 
 ```bash
-sudo wget -O - https://installer.dappnode.io | sudo bash
+curl -fsSL https://installer.dappnode.io | bash
 ```
 
 The installer automatically detects server-class Mac models and installs the full package set including WIFI, IPFS, VPN, WIREGUARD, and HTTPS.
@@ -80,7 +80,7 @@ Once connected, access the Dappnode UI at [http://my.dappnode](http://my.dappnod
 To update Dappnode to the latest version without erasing any data:
 
 ```bash
-sudo wget -O - https://installer.dappnode.io | sudo UPDATE=true bash
+curl -fsSL https://installer.dappnode.io | UPDATE=true bash
 ```
 
 ## Uninstall
@@ -88,7 +88,7 @@ sudo wget -O - https://installer.dappnode.io | sudo UPDATE=true bash
 To uninstall Dappnode components:
 
 ```bash
-wget -qO - https://uninstaller.dappnode.io | sudo bash
+curl -fsSL https://uninstaller.dappnode.io | bash
 ```
 
 :::info

--- a/docs/user/install/macos.md
+++ b/docs/user/install/macos.md
@@ -25,10 +25,10 @@ Make sure Docker Desktop is running before starting the installation. You can ve
 
 ### Desktop / Personal Mac (MacBook, iMac)
 
-If you are running Dappnode on a Mac that you also use as your personal computer, use the `--minimal` flag. This installs only the essential Dappnode components (BIND, DAPPMANAGER, NOTIFICATIONS, PREMIUM), keeping your system lightweight:
+If you are running Dappnode on a Mac that you also use as your personal computer, use the `--lite` flag. This installs a reduced package set (BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, PREMIUM), keeping your system lightweight while enabling VPN access:
 
 ```bash
-sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --minimal
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --lite
 ```
 
 ### Server Mac (Mac mini, Mac Studio, Mac Pro)
@@ -42,7 +42,7 @@ sudo wget -O - https://installer.dappnode.io | sudo bash
 The installer automatically detects server-class Mac models and installs the full package set including WIFI, IPFS, VPN, WIREGUARD, and HTTPS.
 
 :::tip
-If you have a Mac mini that you use as a personal desktop rather than a server, you can force the minimal installation by passing `--minimal`.
+If you have a Mac mini that you use as a personal desktop rather than a server, you can force the lite installation by passing `--lite`.
 :::
 
 ## Connecting to Dappnode

--- a/docs/user/install/overview.md
+++ b/docs/user/install/overview.md
@@ -1,49 +1,87 @@
 ---
 title: "Installation Overview"
-llm_description: "Installation overview: minimum hardware specs and comparison of ISO vs script methods."
+llm_description: "Installation overview: supported platforms, hardware specs by use case, and installation method comparison."
 ---
 
 # Installation Overview
 
-## Specifications & Minimum Requirements
-Dappnode is a Debian-based OS, which makes it friendly with most available commercial hardware. Depending on what you intend to run in your Dappnode you might need higher specifications, but a great number of available features can be used with the following recommendations:
-- Intel Core i5/i7
-- 32 GB RAM
-- 4 TB NVMe storage
+Dappnode can be installed on **Linux (Debian/Ubuntu)** and **macOS** machines. Whether you are setting up a dedicated home server or running Dappnode on your personal computer, choose the platform and installation method that best fits your needs.
 
-As minimum requirements we recommend:
-- Intel Core i3
-- 16 GB RAM
-- 2 TB NVMe or fast SSD storage
+## Supported Platforms
 
-If you don't have enough technical experience to customize your own hardware, remember you can always get a plug n play [Dappnode Home](https://dappnode.com/collections/all) in our online shop.
+| Platform | Installation Methods | Notes |
+| --- | --- | --- |
+| **Linux (Debian/Ubuntu)** | [ISO](/docs/user/install/iso), [Script](/docs/user/install/script) | Recommended for dedicated servers and staking |
+| **macOS** | [Script](/docs/user/install/macos) | Apple Silicon & Intel supported |
+| **ARM (Linux)** | [Script](/docs/user/install/arm) | Raspberry Pi and similar boards |
 
-## Installation Methods
+## Hardware Recommendations
 
-Installing Dappnode can be achieved through two primary methods:
+Hardware requirements depend heavily on your intended use case. Below are general guidelines:
 
-### 1. [ISO Installation](/docs/user/install/iso)
-- **Description**: This method involves downloading the Dappnode ISO file and using it to directly install Dappnode on your system.
-- **Best for**: Most users as it provides a comprehensive setup designed specifically for Dappnode.
+### Home Server (24/7 staking, full nodes)
 
-### 2. [Script Installation](/docs/user/install/script) over Debian-based Distribution
-- **Description**: If you're already running a Debian-based distribution, you can utilize the Dappnode script to facilitate the installation process.
-- **Best for**: Users who want to install Dappnode on a cloud server, ARM device (where it's the only option), or those who desire a specific Debian-based distro.
+This is the recommended setup for staking, running full blockchain nodes, and other always-on workloads.
 
-:::note
-For ARM-based systems, only the script installation method is available.
+| Component | Recommended | Minimum |
+| --- | --- | --- |
+| CPU | Intel Core i5/i7 or AMD equivalent | Intel Core i3 |
+| RAM | 32 GB | 16 GB |
+| Storage | 4 TB NVMe | 2 TB NVMe or fast SSD |
+
+### Personal Desktop / Laptop (light usage)
+
+If you are running Dappnode on your personal computer for lighter workloads (e.g. testing, light node operation, development), lower specs are acceptable:
+
+| Component | Recommended | Minimum |
+| --- | --- | --- |
+| CPU | Intel Core i5 / Apple M1 or better | Intel Core i3 / Apple M1 |
+| RAM | 16 GB | 8 GB |
+| Storage | 1 TB NVMe or SSD | 512 GB SSD |
+
+### AI & Advanced Workloads
+
+Running AI packages or other compute-heavy workloads alongside blockchain nodes requires significantly more resources:
+
+| Component | Recommended |
+| --- | --- |
+| CPU | Intel Core i7/i9 or Apple M2 Pro/Max or better |
+| RAM | 64 GB+ |
+| Storage | 4 TB+ NVMe |
+| GPU | Dedicated GPU recommended for AI inference |
+
+### macOS Compatibility
+
+Dappnode supports macOS on both Apple Silicon (M1/M2/M3/M4) and Intel Macs. Server-class Macs (Mac mini, Mac Studio, Mac Pro) are recommended for always-on usage. Laptops and iMacs can run Dappnode in desktop/personal mode. See the [macOS installation guide](/docs/user/install/macos) for details.
+
+:::tip
+If you don't have enough technical experience to customize your own hardware, you can always get a plug-and-play [Dappnode Home](https://dappnode.com/collections/all) from our online shop.
 :::
 
-Choose the method that best fits your needs and system setup. Make sure to follow the respective installation instructions carefully for a smooth and successful Dappnode deployment.
+## Installation Methods at a Glance
+
+### Linux (Debian/Ubuntu)
+
+| Method | Best For | Link |
+| --- | --- | --- |
+| **ISO** | Clean installs on dedicated machines; wipes disk and installs Dappnode over Debian | [ISO Installation](/docs/user/install/iso) |
+| **Script (server)** | Installing on an existing Debian/Ubuntu system as a 24/7 server | [Script Installation](/docs/user/install/script) |
+| **Script (desktop / `--lite`)** | Installing on a personal Linux desktop or laptop | [Script Installation](/docs/user/install/script) |
+
+### macOS
+
+| Method | Best For | Link |
+| --- | --- | --- |
+| **Script (server)** | Always-on Mac mini / Mac Studio / Mac Pro | [macOS Installation](/docs/user/install/macos) |
+| **Script (desktop / `--minimal`)** | Personal MacBook, iMac, or Mac mini used as a desktop | [macOS Installation](/docs/user/install/macos) |
 
 :::caution Continuous Uptime
 
-Dappnode is designed to run 24/7. Many features and functions within Dappnode, especially blockchain nodes, rely on continuous uptime to maintain their state, sync, and functionality. For instance:
+Dappnode is designed to run 24/7 when used as a server. Many features, especially blockchain nodes and validators, rely on continuous uptime:
 
-- **Blockchain Nodes**: If you have a synced blockchain node and you turn off Dappnode, the node will lose its sync. This means when you turn it back on, it'll take time to catch up to the latest state, which can be resource-intensive and time-consuming.
+- **Blockchain Nodes**: Turning off Dappnode causes nodes to lose sync. Re-syncing can be resource-intensive and time-consuming.
+- **Validator Nodes**: For staking, continuous uptime is crucial. Being offline may result in missed rewards or penalties.
 
-- **Validator Nodes**: For users staking on certain blockchain networks, continuous uptime is crucial. Being offline might result in missed opportunities or even penalties.
-
-Considering these aspects, it's recommended to ensure your Dappnode device remains powered on and running at all times.
+If you are running Dappnode on a personal desktop or laptop, be aware that shutting down or suspending the machine will stop all Dappnode services.
 :::
 

--- a/docs/user/install/script.md
+++ b/docs/user/install/script.md
@@ -1,43 +1,73 @@
 ---
-title: "Script installation"
-llm_description: "Install Dappnode via bash script on Debian/Ubuntu, including prerequisites and update commands."
+title: "Script Installation"
+llm_description: "Install Dappnode via bash script on Debian/Ubuntu, including prerequisites, install modes, and update commands."
 ---
 
-# Script installation
+# Script Installation
 
-You can install Dappnode using the installation script. In this case, we recommend you use Ubuntu or Debian as your operating system.
+You can install Dappnode using the installation script on any Debian-based Linux distribution (Debian, Ubuntu). The script method is also the only option for [ARM devices](/docs/user/install/arm) and [macOS](/docs/user/install/macos).
 
 ## Prerequisites
 
-Before installing Dappnode, you need to install some prerequisites:
+Before installing Dappnode, you need:
 
 - [Docker](https://docs.docker.com/install/)
-- [Docker-compose](https://docs.docker.com/compose/install/)
-- [xz](https://packages.debian.org/sid/xz-utils)
+- [Docker Compose](https://docs.docker.com/compose/install/) (plugin or standalone)
+- [xz-utils](https://packages.debian.org/sid/xz-utils)
 
-To install all the above prerequisites, execute the command below in the terminal of the machine you want to install Dappnode. If you already have the dependencies installed or you want to install them on your own you can skip this step.
+To install all prerequisites at once, run:
 
 ```bash
 sudo wget -O - https://prerequisites.dappnode.io | sudo bash
 ```
 
+If you already have the dependencies installed you can skip this step.
+
 ## Install Dappnode
 
-To install Dappnode, execute the next script:
+### Server (default — full installation)
+
+For a dedicated server running 24/7:
 
 ```bash
 sudo wget -O - https://installer.dappnode.io | sudo bash
 ```
 
+This installs all core components: HTTPS, BIND, IPFS, VPN, WIREGUARD, DAPPMANAGER, WIFI, NOTIFICATIONS, and PREMIUM.
+
+### Desktop / Laptop (lite installation)
+
+For a personal Linux desktop or laptop, use the `--lite` flag to install a reduced set of components:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --lite
+```
+
+This installs: BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, and PREMIUM.
+
+:::caution .dappnode domains on Desktop mode
+When running in `--lite` (desktop) mode, `.dappnode` domain resolution is currently under investigation and may not work as expected. This is a known limitation that is expected to be fixed in a future release.
+:::
+
+### Minimal installation
+
+For the smallest possible footprint (useful for testing or custom setups):
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --minimal
+```
+
+This installs only: BIND, DAPPMANAGER, NOTIFICATIONS, and PREMIUM.
+
 ## Reboot
 
-To finalize the installation once it has finished completing, reboot your machine (you might need to do this twice):
+After the installation completes, reboot your machine (you might need to do this twice):
 
 ```bash
 shutdown -r now
 ```
 
-## Restore to the latest version
+## Restore to the Latest Version
 
 If you are experiencing any problem or just want to make sure you are running the latest Dappnode versions, execute this command in the Dappnode terminal. This will update the core packages to the latest versions without erasing any data from your volumes.
 
@@ -47,8 +77,12 @@ sudo wget -O - https://installer.dappnode.io | sudo UPDATE=true bash
 
 ## Uninstall
 
-This command will uninstall Dappnode components (but not docker et al.).
+This command will uninstall Dappnode components (but not Docker).
 
 ```bash
 wget -qO - https://uninstaller.dappnode.io | sudo bash
 ```
+
+## Advanced Options
+
+The installer supports additional flags and environment variables for fine-grained control over the installation. See the [Advanced Script Options](/docs/user/install/script/advanced) page for the full reference.

--- a/docs/user/install/script/advanced.md
+++ b/docs/user/install/script/advanced.md
@@ -1,0 +1,128 @@
+---
+title: "Advanced Script Options"
+llm_description: "Full reference of all CLI flags and environment variables for the Dappnode install script."
+---
+
+# Advanced Script Options
+
+The Dappnode installation script supports a variety of flags and environment variables that give you fine-grained control over the installation process. Each flag has an equivalent environment variable.
+
+## CLI Flags
+
+| Flag                          | Description                                                                                                               | Equivalent Env Variable     |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `--update`                    | Clean existing downloaded artifacts before installing. Useful to force a fresh re-download of all components.             | `UPDATE=true`               |
+| `--static-ip <ipv4>`          | Set a static IP address for the Dappnode instance.                                                                        | `STATIC_IP=<ipv4>`          |
+| `--local-profile-path <path>` | Use a local `.dappnode_profile` file instead of downloading one from GitHub. Useful for offline or custom installations.  | `LOCAL_PROFILE_PATH=<path>` |
+| `--ipfs-endpoint <url>`       | Override the default IPFS gateway endpoint used to download packages.                                                     | `IPFS_ENDPOINT=<url>`       |
+| `--profile-url <url>`         | Override the URL from which the core packages profile (version list) is downloaded.                                       | `PROFILE_URL=<url>`         |
+| `--minimal`                   | Install only the bare minimum packages: BIND, DAPPMANAGER, NOTIFICATIONS, PREMIUM. No VPN, WIFI, IPFS, or HTTPS.          | `MINIMAL=true`              |
+| `--lite`                      | Install a reduced package set: BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, PREMIUM. No WIFI, IPFS, or HTTPS.        | `LITE=true`                 |
+| `--packages <list>`           | Override the package selection entirely. Comma or space-separated list. DAPPMANAGER is automatically included if omitted. | `PACKAGES=<list>`           |
+| `-h`, `--help`                | Show the help message and exit.                                                                                           | —                           |
+
+:::note
+`--minimal` and `--lite` are mutually exclusive. If both are specified, the installer will exit with an error. If `--packages` is provided, it takes priority over `--minimal` and `--lite`.
+:::
+
+## Environment Variables
+
+All flags can also be passed as environment variables. Environment variables are useful when piping the installer from a URL:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo MINIMAL=true bash
+```
+
+| Variable             | Default                                                                             | Description                                                |
+| -------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `UPDATE`             | `false`                                                                             | Set to `true` to clean cached artifacts before installing. |
+| `STATIC_IP`          | _(empty)_                                                                           | IPv4 address to configure as static IP.                    |
+| `LOCAL_PROFILE_PATH` | _(empty)_                                                                           | Path to a local `.dappnode_profile` file.                  |
+| `IPFS_ENDPOINT`      | `https://ipfs-gateway-dev.dappnode.net`                                             | IPFS gateway URL for downloading packages.                 |
+| `PROFILE_URL`        | `https://github.com/dappnode/DAppNode/releases/latest/download/dappnode_profile.sh` | URL to download the version profile from.                  |
+| `MINIMAL`            | `false`                                                                             | Enable minimal installation mode.                          |
+| `LITE`               | `false`                                                                             | Enable lite installation mode.                             |
+| `PACKAGES`           | _(empty)_                                                                           | Comma or space-separated list of packages to install.      |
+
+## Available Packages
+
+The following packages can be specified with `--packages`:
+
+| Package         | Description                                                           |
+| --------------- | --------------------------------------------------------------------- |
+| `BIND`          | DNS service for `.dappnode` domain resolution                         |
+| `IPFS`          | IPFS node for decentralized package distribution                      |
+| `VPN`           | OpenVPN server for remote access                                      |
+| `WIREGUARD`     | Wireguard VPN server for remote access                                |
+| `DAPPMANAGER`   | Core Dappnode management UI and API (always required)                 |
+| `WIFI`          | WiFi hotspot for local access                                         |
+| `HTTPS`         | HTTPS portal for secure web access (requires ports 80/443 to be free) |
+| `NOTIFICATIONS` | Notification service                                                  |
+| `PREMIUM`       | Premium features                                                      |
+
+:::info
+DAPPMANAGER is required for a functional installation. If you specify `--packages` without including DAPPMANAGER, it will be automatically added.
+
+HTTPS is automatically skipped if ports 80 or 443 are already in use by another service.
+:::
+
+## Installation Mode Summary
+
+| Mode                 | Packages Installed                                                           | Use Case                                      |
+| -------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
+| **Default (server)** | HTTPS, BIND, IPFS, VPN, WIREGUARD, DAPPMANAGER, WIFI, NOTIFICATIONS, PREMIUM | Dedicated 24/7 server                         |
+| **`--lite`**         | BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, PREMIUM                    | Linux desktop / laptop                        |
+| **`--minimal`**      | BIND, DAPPMANAGER, NOTIFICATIONS, PREMIUM                                    | macOS personal use, testing, or custom setups |
+| **`--packages`**     | Custom selection                                                             | Full control over installed components        |
+
+## Examples
+
+### Full server installation with update
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo UPDATE=true bash
+```
+
+### Lite installation for a Linux desktop
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --lite
+```
+
+### Minimal installation for a personal Mac
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --minimal
+```
+
+### Custom package selection
+
+Install only BIND, WIREGUARD, and DAPPMANAGER:
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --packages BIND,WIREGUARD,DAPPMANAGER
+```
+
+### Using a custom IPFS gateway
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --ipfs-endpoint https://my-ipfs-gateway.example.com
+```
+
+### Setting a static IP
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --static-ip 192.168.1.100
+```
+
+### Using a local profile for offline installation
+
+```bash
+sudo bash dappnode_install.sh --local-profile-path /path/to/.dappnode_profile
+```
+
+### Combining flags
+
+```bash
+sudo wget -O - https://installer.dappnode.io | sudo bash -s -- --lite --static-ip 192.168.1.50 --update
+```

--- a/docs/user/install/script/advanced.md
+++ b/docs/user/install/script/advanced.md
@@ -9,17 +9,17 @@ The Dappnode installation script supports a variety of flags and environment var
 
 ## CLI Flags
 
-| Flag                          | Description                                                                                                               | Equivalent Env Variable     |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `--update`                    | Clean existing downloaded artifacts before installing. Useful to force a fresh re-download of all components.             | `UPDATE=true`               |
-| `--static-ip <ipv4>`          | Set a static IP address for the Dappnode instance.                                                                        | `STATIC_IP=<ipv4>`          |
-| `--local-profile-path <path>` | Use a local `.dappnode_profile` file instead of downloading one from GitHub. Useful for offline or custom installations.  | `LOCAL_PROFILE_PATH=<path>` |
-| `--ipfs-endpoint <url>`       | Override the default IPFS gateway endpoint used to download packages.                                                     | `IPFS_ENDPOINT=<url>`       |
-| `--profile-url <url>`         | Override the URL from which the core packages profile (version list) is downloaded.                                       | `PROFILE_URL=<url>`         |
-| `--minimal`                   | Install only the bare minimum packages: BIND, DAPPMANAGER, NOTIFICATIONS, PREMIUM. No VPN, WIFI, IPFS, or HTTPS.          | `MINIMAL=true`              |
-| `--lite`                      | Install a reduced package set: BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, PREMIUM. No WIFI, IPFS, or HTTPS.        | `LITE=true`                 |
-| `--packages <list>`           | Override the package selection entirely. Comma or space-separated list. DAPPMANAGER is automatically included if omitted. | `PACKAGES=<list>`           |
-| `-h`, `--help`                | Show the help message and exit.                                                                                           | —                           |
+| Flag                          | Description                                                                                                                 | Equivalent Env Variable     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `--update`                    | Clean existing downloaded artifacts before installing. Useful to force a fresh re-download of all components.               | `UPDATE=true`               |
+| `--static-ip <ipv4>`          | Set a static IP address for the Dappnode instance.                                                                          | `STATIC_IP=<ipv4>`          |
+| `--local-profile-path <path>` | Use a local `.dappnode_profile` file instead of downloading one from GitHub. Useful for offline or custom installations.    | `LOCAL_PROFILE_PATH=<path>` |
+| `--ipfs-endpoint <url>`       | Override the default IPFS gateway endpoint used to download packages.                                                       | `IPFS_ENDPOINT=<url>`       |
+| `--profile-url <url>`         | Override the URL from which the core packages profile (version list) is downloaded.                                         | `PROFILE_URL=<url>`         |
+| `--minimal`                   | Install only the bare minimum packages: BIND, DAPPMANAGER, NOTIFICATIONS, PREMIUM. No VPN, WIREGUARD, WIFI, IPFS, or HTTPS. | `MINIMAL=true`              |
+| `--lite`                      | Install a reduced package set: BIND, VPN, WIREGUARD, DAPPMANAGER, NOTIFICATIONS, PREMIUM. No WIFI, IPFS, or HTTPS.          | `LITE=true`                 |
+| `--packages <list>`           | Override the package selection entirely. Comma or space-separated list. DAPPMANAGER is automatically included if omitted.   | `PACKAGES=<list>`           |
+| `-h`, `--help`                | Show the help message and exit.                                                                                             | —                           |
 
 :::note
 `--minimal` and `--lite` are mutually exclusive. If both are specified, the installer will exit with an error. If `--packages` is provided, it takes priority over `--minimal` and `--lite`.

--- a/sidebars.js
+++ b/sidebars.js
@@ -411,19 +411,40 @@ const sidebars = {
           id: "user/install/overview",
         },
         {
-          type: "doc",
-          label: "ISO",
-          id: "user/install/iso",
+          type: "category",
+          label: "Linux (Debian/Ubuntu)",
+          items: [
+            {
+              type: "doc",
+              label: "Overview",
+              id: "user/install/linux",
+            },
+            {
+              type: "doc",
+              label: "ISO",
+              id: "user/install/iso",
+            },
+            {
+              type: "doc",
+              label: "Script",
+              id: "user/install/script",
+            },
+            {
+              type: "doc",
+              label: "ARM",
+              id: "user/install/arm",
+            },
+          ],
         },
         {
           type: "doc",
-          label: "Script",
-          id: "user/install/script",
+          label: "macOS",
+          id: "user/install/macos",
         },
         {
           type: "doc",
-          label: "ARM",
-          id: "user/install/arm",
+          label: "Advanced Script Options",
+          id: "user/install/script/advanced",
         },
         {
           type: "doc",


### PR DESCRIPTION
Enhance the installation documentation by adding specific sections for Linux (Debian/Ubuntu) and macOS, updating the overview and sidebar structure to improve navigation and clarity.